### PR TITLE
Add Help method

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -184,6 +184,29 @@ async def product_cycle(
     # Sending the Embed message
     await inter.channel.send(embeds=embed)
 
+    # Slash command to get help information
+    @bot.slash_command(description="Get help information about the bot")
+    async def help(inter):
+        embed = Embed(title="Bot Help")
+        embed.add_field(
+            name="/get_products", value="Gets all available products", inline=False
+        )
+        embed.add_field(
+            name="/product_details",
+            value="Get EoL dates of all cycles of a given product.",
+            inline=False,
+        )
+        embed.add_field(
+            name="/product_cycle", value="Gets details of a single cycle", inline=False
+        )
+        embed.add_field(
+            name="/help", value="Get help information about the bot", inline=False
+        )
+        embed.set_footer(
+            text="Use /help <command> for more details on a specific command."
+        )
+        await inter.channel.send(embed=embed)
+
 
 # Running the bot with the provided token
 bot.run(BOT_TOKEN)


### PR DESCRIPTION
**What does this PR do?**

This pull request introduces a new slash command `/help` to provide help information about the bot. It sends an embed message with a list of available commands and their descriptions.

**Why is this PR needed?**

This PR adds a helpful feature for users to easily access information about the bot's commands, improving the user experience.

**How to test this PR?**

1. Trigger the `/help` command.
2. Verify that the bot sends an embed message with a list of available commands and their descriptions.
3. Ensure that each command listed provides accurate and helpful information.

**Any relevant issues or dependencies?**

None.

**Screenshots (if applicable)**

N/A

**Additional context**

This addition enhances the usability of the bot by providing users with easily accessible help information about its commands.